### PR TITLE
Fix code alerts found by gosec

### DIFF
--- a/pkg/fileserver/server.go
+++ b/pkg/fileserver/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/heathcliff26/simple-fileserver/pkg/filesystem"
 	"github.com/heathcliff26/simple-fileserver/pkg/middleware"
@@ -25,7 +26,8 @@ func NewFileserver(webroot string, index bool) *Fileserver {
 	server := http.FileServer(fs)
 	return &Fileserver{
 		server: &http.Server{
-			Handler: middleware.Logging(server),
+			Handler:     middleware.Logging(server),
+			ReadTimeout: 10 * time.Second,
 		},
 	}
 }

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -25,7 +25,7 @@ func (ifs IndexlessFilesystem) Open(path string) (http.File, error) {
 		index := path + "/index.html"
 		_, err := ifs.fs.Open(index)
 		if err != nil {
-			f.Close()
+			_ = f.Close()
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Ensure that the http server has a sensible ReadTimeout. As file upload is not
supported, a general timeout of 10 seconds is sufficient.

Fix missing error return by ignoring the error.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>