### PR TITLE
CI: Tag release to ensure correct version in binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,27 @@ on:
         description: "Tag container as latest"
         type: boolean
         default: true
+      prerelease:
+        description: "Mark the release as a prerelease"
+        type: boolean
+        default: false
 
 jobs:
+  tag:
+    uses: heathcliff26/ci/.github/workflows/tag.yaml@main
+    permissions:
+      contents: write
+    with:
+      tag: ${{ inputs.tag }}
+      overwrite: ${{ inputs.update }}
+    secrets: inherit
+
   build:
     uses: ./.github/workflows/ci.yaml
     permissions:
       contents: read
       packages: write
+      security-events: write
     with:
       tag: ${{ inputs.tag }}
       latest: ${{ inputs.latest }}
@@ -43,3 +57,4 @@ jobs:
       tag: ${{ inputs.tag }}
       release-artifacts: "release/*"
       artifacts: "simple-fileserver-*"
+      prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
Ensure the binary get's compiled with the correct version information by
creating the tag first.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>