### PR TITLE
Dockerfile: Set explicit --platform for all stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN GOOS=linux GOARCH="${TARGETARCH}" hack/build.sh
 ###############################################################################
 # BEGIN final-stage
 # Create final docker image
-FROM scratch AS final-stage
+FROM --platform=$TARGETPLATFORM scratch AS final-stage
 
 COPY --from=build-stage /app/bin/simple-fileserver /
 


### PR DESCRIPTION
To remove the unknown arch manifest, explicitly set the platform in stages.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>