### PR TITLE
Dockerfile: Use user and group nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY --from=build-stage /app/bin/simple-fileserver /
 
 EXPOSE 8080
 
-USER 1001
+USER 65534:65534
 
 WORKDIR /webroot
 

--- a/tests/e2e/testdata/Dockerfile
+++ b/tests/e2e/testdata/Dockerfile
@@ -1,4 +1,4 @@
 FROM localhost/simple-fileserver:test-e2e
 
-COPY --chown=1001:1001 --chmod=644 index.html /webroot/
-COPY --chown=1001:1001 --chmod=644 testfolder /webroot/testfolder
+COPY --chown=65534:65534 --chmod=644 index.html /webroot/
+COPY --chown=65534:65534 --chmod=644 testfolder /webroot/testfolder


### PR DESCRIPTION
Instead of 1001, which could exist on the target system and have some privileges, use nobody to guarantee that the user has no privileges.

User might need to change the file permissions for their webroot.