### PR TITLE
go.mod: Bump minimum go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heathcliff26/simple-fileserver
 
-go 1.24.0
+go 1.25.0
 
 require github.com/stretchr/testify v1.11.1
 

--- a/tools/copr.spec
+++ b/tools/copr.spec
@@ -10,7 +10,7 @@ License:        Apache-2.0
 URL:            https://github.com/heathcliff26/%{name}
 Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
 
-BuildRequires: golang >= 1.24
+BuildRequires: golang >= 1.25
 
 %global _description %{expand:
 A golang implementation of a minimal http file server.}


### PR DESCRIPTION
Bump the minimum golang version to the oldest supported version.