### PR TITLE
CI: Use goreleaser to build release artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,25 +90,11 @@ jobs:
     needs:
       - lint
       - unit-tests
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: windows
-            arch: amd64
-          - os: windows
-            arch: arm64
     with:
       release: "${{ github.event_name == 'pull_request' && 'devel' || inputs.tag == '' && 'rolling' || inputs.tag }}"
-      goos: "${{ matrix.os }}"
-      goarch: "${{ matrix.arch }}"
-      artifact: "bin/simple-fileserver-${{ matrix.os }}-${{ matrix.arch }}*"
-      artifact-name: "simple-fileserver-${{ matrix.os }}-${{ matrix.arch }}"
-      cmd: "hack/build.sh simple-fileserver-${{ matrix.os }}-${{ matrix.arch }}"
+      artifact: "dist/simple-fileserver*"
+      artifact-name: "simple-fileserver"
+      cmd: "make release"
     secrets: inherit
 
   build-image:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,6 @@ jobs:
       update: ${{ inputs.update }}
       tag: ${{ inputs.tag }}
       release-artifacts: "release/*"
-      artifacts: "simple-fileserver-*"
+      artifacts: "simple-fileserver"
       prerelease: ${{ inputs.prerelease }}
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore binaries
 /bin
+/dist
 
 # Generated go-test coverage reports
 coverprofiles/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+project_name: simple-fileserver
+
+env:
+  - CGO_ENABLED=0
+  - RELEASE_VERSION={{ if index .Env "RELEASE_VERSION"  }}{{ .Env.RELEASE_VERSION }}{{ else }}devel{{ end }}
+
+builds:
+  - binary: simple-fileserver
+    main: ./cmd
+    goos:
+      - linux
+      - windows
+    goarch:
+      - arm64
+      - amd64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -X github.com/heathcliff26/simple-fileserver/pkg/version.gitVersion={{ .Env.RELEASE_VERSION }} -X github.com/heathcliff26/simple-fileserver/pkg/version.gitCommit={{ .Commit }}
+
+archives:
+  - formats: ["binary"]
+
+changelog:
+  disable: true
+release:
+  disable: true

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ build:
 build-image:
 	podman build -t $(REPOSITORY)/$(CONTAINER_NAME):$(TAG) .
 
+# Build all artifacts used for release, except the container images
+release:
+	hack/release.sh
+
 # Run unit-tests
 test:
 	go test -v -coverprofile=coverprofile.out ./cmd/... ./pkg/...
@@ -73,6 +77,7 @@ help:
 	default \
 	build \
 	build-image \
+	release \
 	test \
 	test-e2e \
 	update-deps \

--- a/hack/clean.sh
+++ b/hack/clean.sh
@@ -4,7 +4,7 @@ set -e
 
 base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)/.."
 
-folders=("bin" "coverprofiles" "tmp" "x86_64" "aarch64")
+folders=("bin" "dist" "coverprofiles" "tmp" "x86_64" "aarch64")
 files=("coverprofile.out")
 
 for folder in "${folders[@]}"; do

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -e
+
+base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath | xargs dirname)"
+dist_dir="${base_dir}/dist"
+bin_dir="${base_dir}/bin"
+name="$(yq -r '.project_name' "${base_dir}/.goreleaser.yaml")"
+
+echo "Checking if goreleaser is installed:"
+if command -v goreleaser &>/dev/null; then
+    echo "goreleaser is installed"
+    goreleaser="$(command -v goreleaser)"
+else
+    echo "goreleaser is not installed, downloading latest version..."
+    LATEST="$(curl -sf https://goreleaser.com/static/latest)"
+    [ -e "${bin_dir}" ] || mkdir "${bin_dir}"
+    arch="$(uname -m)"
+    [ "${arch}" != "aarch64" ] || arch="arm64"
+    curl -SL -o "${bin_dir}/goreleaser.tar.gz" "https://github.com/goreleaser/goreleaser/releases/download/${LATEST}/goreleaser_$(uname -s)_${arch}.tar.gz"
+    tar -xzf "${bin_dir}/goreleaser.tar.gz" -C "${bin_dir}" goreleaser
+    rm "${bin_dir}/goreleaser.tar.gz"
+    goreleaser="${bin_dir}/goreleaser"
+fi
+
+echo "Building releaser artifacts with goreleaser"
+${goreleaser} release --skip=announce,archive,publish,validate --clean
+
+echo "Moving release artifacts to top level of dist directory"
+artifacts="$(cat "${dist_dir}/artifacts.json" | jq -r -c '.[]')"
+echo "${artifacts}" | while read -r artifact; do
+    if ! [[ "$(echo "${artifact}" | jq -r '.name')" =~ ^${name}(\.exe)?$ ]]; then
+        continue
+    fi
+
+    path="${base_dir}/$(echo "${artifact}" | jq -r '.path')"
+    goarch="$(echo "${artifact}" | jq -r '.goarch')"
+    ext="$(echo "${artifact}" | jq -r '.extra.Ext')"
+
+    mv "${path}" "${dist_dir}/${name}-${goarch}${ext}"
+
+    path="$(dirname "${path}")"
+    rm -r "${path}"
+done
+
+
+echo "Cleaning up dist directory"
+rm -r "${dist_dir}/artifacts.json" "${dist_dir}/config.yaml" "${dist_dir}/metadata.json"


### PR DESCRIPTION
Instead of a matrix build job, use goreleaser instead.